### PR TITLE
Update socket.go

### DIFF
--- a/backend/sockets/websocket/socket.go
+++ b/backend/sockets/websocket/socket.go
@@ -159,15 +159,7 @@ func (w *Socket) readLoop() {
 		// Read from the websocket.
 		_, data, err := w.ws.ReadMessage()
 		if err != nil {
-			// Only log errors if this is not EOF and
-			// if the socket was not closed already.
-			// The gorilla socket returns the following string if the socket is
-			// closed and the read message request fails: "websocket: close 1001 "
-			// Currently there is no better solution to determind this, by comparing
-			// the error string message.
-			// TODO: Provide a patch to the gorilla websocket package to solve this dirty hack.
-			if err != io.EOF && !w.IsClosed() &&
-				strings.TrimSpace(err.Error()) != "websocket: close 1001" {
+			if err != io.EOF && !w.IsClosed() {
 				// Log
 				log.L.WithFields(logrus.Fields{
 					"remoteAddress": w.RemoteAddr(),


### PR DESCRIPTION
Remove dirty hack, because gorilla websocket does not use 1001 error code

It was used here:

```
    case CloseMessage:
        c.WriteControl(CloseMessage, []byte{}, time.Now().Add(writeWait))
        closeCode := CloseNoStatusReceived
        closeText := ""
        if len(payload) >= 2 {
            closeCode = int(binary.BigEndian.Uint16(payload))
            closeText = string(payload[2:])
        }
        return noFrame, &CloseError{Code: closeCode, Text: closeText}
    }
```
