### PR TITLE
added SetLogOutput and prefixed formatter

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -23,6 +23,7 @@ package log
 
 import (
 	"github.com/Sirupsen/logrus"
+	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 
 var (
@@ -32,6 +33,6 @@ var (
 
 func init() {
 	// Set the default log options.
-	L.Formatter = new(logrus.TextFormatter)
+	L.Formatter = new(prefixed.TextFormatter)
 	L.Level = logrus.DebugLevel
 }

--- a/server.go
+++ b/server.go
@@ -22,12 +22,14 @@ package glue
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"sync"
 	"time"
 
 	"github.com/desertbit/glue/backend"
+	"github.com/desertbit/glue/log"
 )
 
 //####################//
@@ -206,6 +208,11 @@ func (s *Server) Run() error {
 // ServeHTTP implements the HTTP Handler interface of the http package.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.bs.ServeHTTP(w, r)
+}
+
+// SetLogOutput allows to set a different output destination for the logger
+func SetLogOutput(w io.Writer) {
+	log.L.Out = w
 }
 
 //########################//


### PR DESCRIPTION
SetLogOutput allows adding an io.Writer as the loggers output destination.
This is useful for logging into a file or into a stream multiplexer.
The prefixed formatter allows adding prefixes to log messages, which is helpful for debugging.
Also it has a very nice output.