### PR TITLE
Handle Sirupsen -> sirupsen organizaiton rename

### DIFF
--- a/backend/server.go
+++ b/backend/server.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/desertbit/glue/backend/sockets/ajaxsocket"
 	"github.com/desertbit/glue/backend/sockets/websocket"
 	"github.com/desertbit/glue/log"

--- a/backend/sockets/ajaxsocket/server.go
+++ b/backend/sockets/ajaxsocket/server.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/desertbit/glue/log"
 	"github.com/desertbit/glue/utils"
 )

--- a/backend/sockets/websocket/server.go
+++ b/backend/sockets/websocket/server.go
@@ -21,7 +21,7 @@ package websocket
 import (
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/desertbit/glue/log"
 	"github.com/desertbit/glue/utils"
 	"github.com/gorilla/websocket"

--- a/backend/sockets/websocket/socket.go
+++ b/backend/sockets/websocket/socket.go
@@ -27,7 +27,7 @@ import (
 	"github.com/desertbit/glue/backend/global"
 	"github.com/desertbit/glue/log"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/gorilla/websocket"
 )
 

--- a/log/log.go
+++ b/log/log.go
@@ -22,7 +22,7 @@
 package log
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/socket.go
+++ b/socket.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/blang/semver"
 	"github.com/desertbit/glue/backend"
 	"github.com/desertbit/glue/log"


### PR DESCRIPTION
This commit fixes issue #11 by renaming all imports
to rely on the new lower-case import for logrus:

- github.com/sirupsen/logrus