### PR TITLE
Closes #14 Update license to dual MIT and GPL3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,37 @@
+Copyright (c) 2019 Roland Singer. All rights reserved.
+
+This software is provided "as is," without warranty of any kind,
+express or implied.  In no event shall the author or contributors
+be held liable for any damages arising in any way from the use of
+this software.
+
+The contents of this file are DUAL-LICENSED.  You may modify and/or
+redistribute this software according to the terms of one of the
+following two licenses (at your option):
+
+LICENSE 1 (MIT License):
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+LICENSE 2 (GNU GPL v3):
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
   "keywords": [
     "[\"socket\"]"
   ],
-  "license": "GPL3",
+  "license": "(MIT OR GPL3)",
   "ignore": [
     "**/*",
     "!client/*",

--- a/client/package.json
+++ b/client/package.json
@@ -15,5 +15,5 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Roland Singer <roland.singer@desertbit.com>",
-  "license": "GPL3"
+  "license": "(MIT OR GPL3)"
 }


### PR DESCRIPTION
I've based this dual license off of the libpng dual BSD GPL license:
https://raw.githubusercontent.com/glennrp/libpng/libpng16/contrib/gregbook/LICENSE

Please feel free to make or request modifications!